### PR TITLE
Add flag for Zenodo sandbox URL.

### DIFF
--- a/zenodo_get/zget.py
+++ b/zenodo_get/zget.py
@@ -203,6 +203,15 @@ def zenodo_get(argv=None):
         help='Output directory, created if necessary. Default: current directory.',
     )
 
+    parser.add_option(
+        '-s',
+        '--sandbox',
+        action='store_true',
+        dest='sandbox',
+        help='Use Zenodo Sandbox URL.',
+        default=False,
+    )
+
     (options, args) = parser.parse_args(argv)
 
     if options.cite:
@@ -262,7 +271,11 @@ def zenodo_get(argv=None):
             recordID = options.record
         recordID = recordID.strip()
 
-        url = 'https://zenodo.org/api/records/'
+        if not options.sandbox:
+            url = 'https://zenodo.org/api/records/'
+        else:
+            url = 'https://sandbox.zenodo.org/api/records/'
+
         try:
             r = requests.get(url + recordID, timeout=options.timeout)
         except requests.exceptions.ConnectTimeout:


### PR DESCRIPTION
Hi!

Thanks for writing this useful utility!
I am preparing a submission and am experimenting with Zenodo using their 'sandbox' environment (https://sandbox.zenodo.org/).
To enable this together with `zenodo_get` I added a command line flag to use the `sandbox` URL (-s or --sandbox).
Maybe this could be generally useful?

Cheers!