### PR TITLE
preserve dataset directory hierarchy

### DIFF
--- a/zenodo_get/zget.py
+++ b/zenodo_get/zget.py
@@ -344,9 +344,11 @@ def zenodo_get(argv=None):
                         continue
 
                     for _ in range(options.retry + 1):
+                        link = url = unquote(link)
+                        # preserve dataset hierarchy, ensure dir exists
+                        Path(fname).parent.mkdir(parents=True, exist_ok=True)
                         try:
-                            link = url = unquote(link)
-                            filename = wget.download(link)
+                            wget.download(link, out=fname)
                         except Exception:
                             eprint(f'  Download error. Original link: {link}')
                             time.sleep(options.pause)
@@ -364,14 +366,14 @@ def zenodo_get(argv=None):
                         continue
 
                     eprint()
-                    h1, h2 = check_hash(filename, checksum)
+                    h1, h2 = check_hash(fname, checksum)
                     if h1 == h2:
                         eprint(f'Checksum is correct. ({h1})')
                     else:
                         eprint(f'Checksum is INCORRECT!({h1} got:{h2})')
                         if not options.keep:
                             eprint('  File is deleted.')
-                            os.remove(filename)
+                            os.remove(fname)
                         else:
                             eprint('  File is NOT deleted!')
                         if not options.error:


### PR DESCRIPTION
the wget.donwload function does not preserve it on its own, which for some datasets with a directory hierarchy with files of similar names would result in many file.x, file (1).x, file (2).x copies