### PR TITLE
Align with new Zenodo API

### DIFF
--- a/zenodo_get/zget.py
+++ b/zenodo_get/zget.py
@@ -311,7 +311,7 @@ def zenodo_get(argv=None):
             if options.md5 is not None:
                 with open('md5sums.txt', 'wt') as md5file:
                     for f in files:
-                        fname = f['key']
+                        fname = f['filename']
                         checksum = f['checksum'].split(':')[-1]
                         md5file.write(f'{checksum}  {fname}\n')
 
@@ -323,7 +323,7 @@ def zenodo_get(argv=None):
                 else:
                     with open(options.wget, 'wt') as wgetfile:
                         for f in files:
-                            fname = f['key']
+                            fname = f['filename']
                             link = 'https://zenodo.org/record/{}/files/{}'.format(
                                 recordID, fname
                             )

--- a/zenodo_get/zget.py
+++ b/zenodo_get/zget.py
@@ -306,7 +306,7 @@ def zenodo_get(argv=None):
         if r.ok:
             js = r.json()
             files = js['files']
-            total_size = sum(f['size'] for f in files)
+            total_size = sum(f['filesize'] for f in files)
 
             if options.md5 is not None:
                 with open('md5sums.txt', 'wt') as md5file:
@@ -342,7 +342,7 @@ def zenodo_get(argv=None):
                         eprint('Already successfully downloaded files are kept.')
                         break
                     link = f['links']['self']
-                    size = f['size'] / 2 ** 20
+                    size = f['filesize'] / 2 ** 20
                     eprint()
                     eprint(f'Link: {link}   size: {size:.1f} MB')
                     fname = f['key']

--- a/zenodo_get/zget.py
+++ b/zenodo_get/zget.py
@@ -345,7 +345,7 @@ def zenodo_get(argv=None):
                     size = f['filesize'] / 2 ** 20
                     eprint()
                     eprint(f'Link: {link}   size: {size:.1f} MB')
-                    fname = f['key']
+                    fname = f['filename']
                     checksum = f['checksum']
 
                     remote_hash, local_hash = check_hash(fname, checksum)


### PR DESCRIPTION
This is a work-in-progress attempt at fixing #19.
@dvolgyes feel free to close it or use it as a basis for further work in this direction.

The `key->filename` and `size->filesize` replacements look reasonable (see https://developers.zenodo.org).
Tests now fail at this stage:
```python traceback
Link: https://zenodo.org/api/records/1215979/files/f4354a10-2700-4277-875f-04ce02cd81f4   size: 0.1 MB
Traceback (most recent call last):
  File "/home/tommaso/Fractal/zenodo_get/zenodo_get/__main__.py", line 5, in <module>
    zenodo_get.zenodo_get()
  File "/home/tommaso/Fractal/zenodo_get/zenodo_get/zget.py", line 351, in zenodo_get
    remote_hash, local_hash = check_hash(fname, checksum)
  File "/home/tommaso/Fractal/zenodo_get/zenodo_get/zget.py", line 59, in check_hash
    algorithm, value = checksum.split(':')
ValueError: not enough values to unpack (expected 2, got 1)
```