### PR TITLE
check for true/false rather than None when deciding whether to output md5sums.txt

### DIFF
--- a/tests/test.sh
+++ b/tests/test.sh
@@ -13,8 +13,16 @@ $CMD  0 x && false || true
 $CMD  https://invalid && false || true
 
 # tests expected to pass
-$CMD  1215979 -m -e -k
+rm -r md5sums.txt
 $CMD  -r 1215979 -w urls.txt -n
+
+# Ensure that md5sums.txt is not created when it is not wanted
+[ ! -f "md5sums.txt" ]
+
+# Ensure that md5sums.txt is created when it is wanted
+$CMD  1215979 -m -e -k
+[ -f "md5sums.txt" ]
+
 $CMD  -r 1215979 -w -
 $CMD  10.5281/zenodo.1215979 -R 3 -p 2 -n
 $CMD  -d 10.5281/zenodo.1215979

--- a/zenodo_get/zget.py
+++ b/zenodo_get/zget.py
@@ -330,7 +330,7 @@ def zenodo_get(argv=None):
 
             total_size = sum((f.get("filesize") or f["size"]) for f in files)
 
-            if options.md5 is not None:
+            if options.md5:
                 with open("md5sums.txt", "wt") as md5file:
                     for f in files:
                         fname = f.get("filename") or f["key"]


### PR DESCRIPTION
This will fix issue #32.